### PR TITLE
litebastion: Support requests on a local endpoint

### DIFF
--- a/bastion/bastion.go
+++ b/bastion/bastion.go
@@ -90,11 +90,12 @@ func New(c *Config) (*Bastion, error) {
 // ConfigureServer sets up srv to handle backend connections to the bastion. It
 // wraps TLSConfig.GetConfigForClient to intercept backend connections, and sets
 // TLSNextProto for the bastion ALPN protocol. The original tls.Config is still
-// used for non-bastion backend connections.
+// used for non-bastion backend connections *unless* disableRequests is set (in
+// which case srv will not continue TLS handshakes with non-backend clients).
 //
 // Note that since TLSNextProto won't be nil after a call to ConfigureServer,
 // the caller might want to call [http2.ConfigureServer] as well.
-func (b *Bastion) ConfigureServer(srv *http.Server) error {
+func (b *Bastion) ConfigureServer(srv *http.Server, disableRequests bool) error {
 	if srv.TLSNextProto == nil {
 		srv.TLSNextProto = make(map[string]func(*http.Server, *tls.Conn, http.Handler))
 	}
@@ -127,6 +128,9 @@ func (b *Bastion) ConfigureServer(srv *http.Server) error {
 				// This is a bastion connection from a backend.
 				return bastionTLSConfig, nil
 			}
+		}
+		if disableRequests {
+			return nil, fmt.Errorf("connection rejected: missing bastion ALPN")
 		}
 		if oldGetConfigForClient != nil {
 			return oldGetConfigForClient(chi)

--- a/bastion/example_test.go
+++ b/bastion/example_test.go
@@ -55,7 +55,7 @@ func Example() {
 	}
 	// ConfigureServer sets up TLSNextProto and a tls.Config.GetConfigForClient
 	// for backend connections.
-	if err := b.ConfigureServer(hs); err != nil {
+	if err := b.ConfigureServer(hs, false); err != nil {
 		log.Fatalln("failed to configure bastion:", err)
 	}
 	// HTTP/2 needs to be explicitly re-enabled if desired because it's only

--- a/cmd/litebastion/README.md
+++ b/cmd/litebastion/README.md
@@ -23,6 +23,14 @@ acceptable client/witness key hashes.
     -host string
             host to obtain ACME certificate for
 
+If you intend to protect backends from unwanted traffic and not forward
+everything, consider only accepting requests to backends on localhost.
+This is for example useful when running a bastion for your own log, or
+for other logs that you trust and somehow gave authenticated access.
+
+    -local-requests-at int
+            only accept non-backend requests at 127.0.0.1:PORT
+
 Since litebastion needs to operate at a lower level than HTTPS on the witness
 side, it can't be behind a reverse proxy, and needs to configure its own TLS
 certificate. Use the `-cache`, `-email`, and `-host` flags to configure the ACME

--- a/cmd/litebastion/litebastion.go
+++ b/cmd/litebastion/litebastion.go
@@ -34,6 +34,7 @@ import (
 )
 
 var listenAddr = flag.String("listen", "localhost:8443", "host and port to listen at")
+var localRequestsAt = flag.Int("local-requests-at", 0, "only accept non-backend requests at 127.0.0.1:PORT")
 var testCertificates = flag.Bool("testcert", false, "use localhost.pem and localhost-key.pem instead of ACME")
 var autocertCache = flag.String("cache", "", "directory to cache ACME certificates at")
 var autocertHost = flag.String("host", "", "host to obtain ACME certificate for")
@@ -145,6 +146,14 @@ func main() {
 		})
 	}
 
+	requestsOnLocalhost := *localRequestsAt != 0
+	localAddr := fmt.Sprintf("127.0.0.1:%d", *localRequestsAt)
+	hsLocalRequests := &http.Server{
+		Addr:         localAddr,
+		Handler:      http.MaxBytesHandler(mux, 10*1024),
+		ReadTimeout:  5 * time.Second,
+		WriteTimeout: 5 * time.Second,
+	}
 	hs := &http.Server{
 		Addr:         *listenAddr,
 		Handler:      http.MaxBytesHandler(mux, 10*1024),
@@ -155,7 +164,7 @@ func main() {
 			GetCertificate: getCertificate,
 		},
 	}
-	if err := b.ConfigureServer(hs); err != nil {
+	if err := b.ConfigureServer(hs, requestsOnLocalhost); err != nil {
 		logFatal("failed to configure bastion", "err", err)
 	}
 	if err := http2.ConfigureServer(hs, nil); err != nil {
@@ -167,6 +176,12 @@ func main() {
 	defer stop()
 	e := make(chan error, 1)
 	go func() { e <- hs.ListenAndServeTLS("", "") }()
+
+	if requestsOnLocalhost {
+		slog.Info("only listening for non-backend requests locally", "addr", localAddr)
+		go func() { e <- hsLocalRequests.ListenAndServe() }()
+	}
+
 	select {
 	case <-ctx.Done():
 		slog.Info("shutting down on interrupt")


### PR DESCRIPTION
This commit makes it possible to receive backend connections from the public internet while *only* accepting requests to those backends on a different endpoint (forced on 127.0.0.1 because of being HTTP only).

This is for example useful when running a bastion host on the same system as a log; or when the bastion host operator has its own authenticated interface to inject the -local-request-at endpoint.