### PR TITLE
litebastion: fix empty backends file

### DIFF
--- a/cmd/litebastion/litebastion.go
+++ b/cmd/litebastion/litebastion.go
@@ -92,6 +92,9 @@ func main() {
 		}
 		bs := strings.TrimSpace(string(backendsList))
 		for _, line := range strings.Split(bs, "\n") {
+			if line == "" {
+				continue
+			}
 			l, err := hex.DecodeString(line)
 			if err != nil {
 				return fmt.Errorf("invalid backend: %q", line)


### PR DESCRIPTION
If the backends file is empty, `strings.Split` returns a slice containing an empty string, causing litebastion to exit with `invalid backend: ""`.