### PR TITLE
keyserver: share a link to specific email lookup

### DIFF
--- a/cmd/age-keyserver/templates/home.html
+++ b/cmd/age-keyserver/templates/home.html
@@ -116,14 +116,20 @@
 			}
 		});
 
-		document.addEventListener("DOMContentLoaded", () => {
+		function initLookupFromQuery() {
 			const params = new URLSearchParams(document.location.search);
 			const emailParam = params.get("email");
 			if (emailParam !== null) {
 				document.getElementById('lookup-email').value = emailParam;
 				document.getElementById('lookup-form').requestSubmit();
 			}
-		});
+		}
+
+		if (document.readyState === 'loading') {
+			document.addEventListener("DOMContentLoaded", initLookupFromQuery);
+		} else {
+			initLookupFromQuery();
+		}
 	</script>
 </body>
 </html>


### PR DESCRIPTION
Auto-fill the lookup form when an ?email= query parameter is present in the page URL and automatically submit the form. This adds a small client-side snippet that reads the "email" parameter, populates the lookup-email input, and triggers requestSubmit() on the lookup-form.

This improves user experience by allowing direct links that pre-populate and run key lookups without extra clicks, useful for sharing and deep linking to specific email lookups. The change is isolated to the home template and does not affect existing lookup behavior when no parameter is provided.