### PR TITLE
internal/witness: Enforce non-empty origin

### DIFF
--- a/internal/witness/witness.go
+++ b/internal/witness/witness.go
@@ -200,7 +200,10 @@ func (w *Witness) processAddCheckpointRequest(body []byte, bastion string) (cosi
 			return nil, errBadRequest
 		}
 	}
-	origin, _, _ := strings.Cut(string(noteBytes), "\n")
+	origin, _, ok := strings.Cut(string(noteBytes), "\n")
+	if !ok || origin == "" {
+		return nil, errBadRequest
+	}
 	l = l.With("origin", origin)
 	bastions, err := w.getBastions(origin)
 	if err != nil {


### PR DESCRIPTION
And also fail request early if note is malformed with only a single line (no newline after origin).