### PR TITLE
cmd/litebastion: fix -obscurity documentation

### DIFF
--- a/cmd/litebastion/README.md
+++ b/cmd/litebastion/README.md
@@ -39,7 +39,7 @@ the provided certificate and private key are used instead. The certificate and
 key are reloaded on SIGHUP.
 
     -obscurity
-            enable obscurity mode (disable / and /logz endpoints)
+            enable obscurity mode (disable /logz endpoint)
 
     -listen-http [HOST:]PORT
             only accept HTTP requests at http://HOST:PORT or http://localhost:PORT

--- a/cmd/litebastion/litebastion.go
+++ b/cmd/litebastion/litebastion.go
@@ -45,7 +45,7 @@ var autocertHost = flag.String("host", "", "host to obtain ACME certificate for"
 var autocertEmail = flag.String("email", "", "")
 var allowedBackendsFile = flag.String("backends", "", "file of accepted key hashes, one per line, reloaded on SIGHUP")
 var homeRedirect = flag.String("home-redirect", "", "redirect / to this URL")
-var obscurityFlag = flag.Bool("obscurity", false, "enable obscurity mode (disable / and /logz endpoints)")
+var obscurityFlag = flag.Bool("obscurity", false, "enable obscurity mode (disable /logz endpoint)")
 
 type keyHash [sha256.Size]byte
 


### PR DESCRIPTION
Unlike litewitness, litebastion does not publish any dynamic information on / and -obscurity doesn't disable it, but the doc strings/README fragment got copy pasted over from litewitness, claiming that it does.

Remove the mention of / so it doesn't cause confusion.