### PR TITLE
cmd/litebastion: allow comment lines in backend list

### DIFF
--- a/cmd/litebastion/README.md
+++ b/cmd/litebastion/README.md
@@ -14,6 +14,8 @@ requests over that connection. The bastion then proxies requests received at
 The only configuration file of litebastion is the backends file, which lists the
 acceptable client/witness key hashes.
 
+Empty lines and lines starting with `#` are ignored.
+
     -listen string
             host and port to listen at (default "localhost:8443")
     -cache string

--- a/cmd/litebastion/litebastion.go
+++ b/cmd/litebastion/litebastion.go
@@ -105,7 +105,7 @@ func main() {
 		}
 		bs := strings.TrimSpace(string(backendsList))
 		for _, line := range strings.Split(bs, "\n") {
-			if line == "" {
+			if line == "" || line[0] == '#' {
 				continue
 			}
 			l, err := hex.DecodeString(line)

--- a/cmd/litebastion/litebastion.go
+++ b/cmd/litebastion/litebastion.go
@@ -105,7 +105,7 @@ func main() {
 		}
 		bs := strings.TrimSpace(string(backendsList))
 		for _, line := range strings.Split(bs, "\n") {
-			if line == "" || line[0] == '#' {
+			if strings.TrimSpace(line) == "" || line[0] == '#' {
 				continue
 			}
 			l, err := hex.DecodeString(line)


### PR DESCRIPTION
Skip over comment lines starting with "#". This is useful for keeping the file organized.