### PR TITLE
mpt: Remove val from inclusion proof

### DIFF
--- a/mpt/DESIGN.md
+++ b/mpt/DESIGN.md
@@ -185,11 +185,9 @@ A proof of the empty tree is `mptproof` followed by a 0x00 byte.
 It only applies when the tree hash is the empty tree hash,
 and it disproves the existence of all possible keys.
 
-A proof confirming the existence of a key starts with `mptproof` followed by a 0x01 byte
-and then a 32-byte value _v_.
-The hash of the key's leaf node can be recomputed as _h_ = SHA256(_key_ || _v_).
-If the tree is a single node, that is the entire proof: the verifier must check that
-_h_ = _snap_.
+A proof confirming the existence of a key starts with `mptproof` followed by a 0x01 byte.
+The hash of the key's leaf node can be recomputed as _h_ = SHA256(_key_ || _v_)
+where _v_ is the value associated with the key.
 If the tree contains more than one node, the proof continues with
 one or more descriptions of sibling nodes along the path back to the tree root.
 Each sibling node is encoded as 33 bytes: a one-byte bit position _b_

--- a/mpt/dmem.go
+++ b/mpt/dmem.go
@@ -355,13 +355,12 @@ func (n *diskNode) prove(t *diskTree, pbit int, key Key) (Proof, error) {
 		if err != nil {
 			return nil, err
 		}
-		var p Proof
 		if nkey == key {
-			p = Proof(proofConfirm)
+			return Proof(proofConfirm), nil
 		} else {
-			p = append(Proof(proofDeny), nkey[:]...)
+			p := append(Proof(proofDeny), nkey[:]...)
+			return append(p, nval[:]...), nil
 		}
-		return append(p, nval[:]...), nil
 	}
 
 	childAddr, sibAddr := n.left(), n.right()

--- a/mpt/mem.go
+++ b/mpt/mem.go
@@ -258,13 +258,12 @@ func (n *memNode) prove(pbit int, key Key) Proof {
 	nbit := n.bit()
 	if nbit <= pbit {
 		// view n as leaf
-		var p Proof
 		if n.key == key {
-			p = Proof(proofConfirm)
+			return Proof(proofConfirm)
 		} else {
-			p = append(Proof(proofDeny), n.key[:]...)
+			p := append(Proof(proofDeny), n.key[:]...)
+			return append(p, n.val[:]...)
 		}
-		return append(p, n.val[:]...)
 	}
 
 	var sib Hash

--- a/mpt/tree.go
+++ b/mpt/tree.go
@@ -281,35 +281,41 @@ var (
 	ErrMismatchedProof = errors.New("mismatched mpt proof")
 )
 
-// Verify verifies that p is a valid proof of a lookup for key in snap,
-// returning the proved lookup result (val, ok).
-// If the proof is not valid for key in snap, Verify returns a non-nil error.
-func Verify(snap Snapshot, key Key, proof Proof) (val Val, ok bool, err error) {
-	if string(proof) == proofEmpty {
-		if snap.Hash == emptyTreeHash() {
-			return Val{}, false, nil
-		}
-		return Val{}, false, ErrMismatchedProof
-	}
+type ProofType int
 
-	var data []byte
-	var pkey Key
-	if data, ok = bytes.CutPrefix(proof, []byte(proofConfirm)); ok && len(data) >= 32 {
-		pkey = key
-		val, data = Val(data[:32]), data[32:]
-	} else if data, ok = bytes.CutPrefix(proof, []byte(proofDeny)); ok && len(data) >= 64 {
-		pkey, val, data = Key(data[:32]), Val(data[32:64]), data[64:]
-		if pkey == key {
-			return Val{}, false, ErrMalformedProof
-		}
+const (
+	Inclusion ProofType = iota
+	Noninclusion
+)
+
+// GetProofType returns the type (inclusion/noninclusion) of proof. If the proof does not
+// have an identifiable type, GetProofType returns a non-nil error of ErrMalformedProof
+func GetProofType(proof Proof) (ty ProofType, err error) {
+	// Confirm is an inclusion proof. Deny and Empty are noninclusion proofs
+	if _, ok := bytes.CutPrefix(proof, []byte(proofConfirm)); ok {
+		return Inclusion, nil
+	} else if _, ok := bytes.CutPrefix(proof, []byte(proofEmpty)); ok {
+		return Noninclusion, nil
+	} else if _, ok := bytes.CutPrefix(proof, []byte(proofDeny)); ok {
+		return Noninclusion, nil
+	} else {
+		return -1, ErrMalformedProof
 	}
+}
+
+// verifyInternal verifies that key, val, and data (an MPT proof minus the header parts)
+// produce the root hash of snap, and verifies that pkey and key have the same path in the
+// tree. If the former condition fails, verifyInternal returns ErrMismatchedProof. If the
+// latter condition fails, or if the proof is otherwise malformed, verifyInternal returns
+// ErrMalformedProof.
+func verifyInternal(snap Snapshot, key Key, pkey Key, val Val, data []uint8) (err error) {
 	h := hashLeaf(pkey, val)
 	b := 256
 	for len(data) >= 1+32 && int(data[0]) < b {
 		var sib Hash
 		b, sib, data = int(data[0]), Hash(data[1:1+32]), data[1+32:]
 		if key.bit(b) != pkey.bit(b) {
-			return Val{}, false, ErrMalformedProof
+			return ErrMalformedProof
 		}
 		if key.bit(b) == 0 {
 			h = hashInner(b, h, sib)
@@ -317,13 +323,52 @@ func Verify(snap Snapshot, key Key, proof Proof) (val Val, ok bool, err error) {
 			h = hashInner(b, sib, h)
 		}
 	}
-	if len(data) != 0 || h != snap.Hash {
-		return Val{}, false, ErrMalformedProof
+	if len(data) != 0 {
+		return ErrMalformedProof
 	}
+	if h != snap.Hash {
+		return ErrMismatchedProof
+	}
+
+	return nil
+}
+
+// VerifyInclusion verifies that p is a valid proof of a lookup for (key, val) in snap.
+// If the proof is not valid, VerifyInclusion returns a non-nil error.
+func VerifyInclusion(snap Snapshot, key Key, val Val, proof Proof) (err error) {
+	data, ok := bytes.CutPrefix(proof, []byte(proofConfirm))
+	if !ok {
+		return ErrMalformedProof
+	}
+
+	err = verifyInternal(snap, key, key, val, data)
+	return err
+}
+
+// VerifyNoninclusion verifies that p is a valid proof that key is not in snap
+// If the proof is not valid, VerifyNoninclusion returns a non-nil error.
+func VerifyNoninclusion(snap Snapshot, key Key, proof Proof) (err error) {
+	if string(proof) == proofEmpty {
+		if snap.Hash == emptyTreeHash() {
+			return nil
+		}
+		return ErrMismatchedProof
+	}
+
+	data, ok := bytes.CutPrefix(proof, []byte(proofDeny))
+	if !ok || len(data) < 64 {
+		return ErrMalformedProof
+	}
+
+	var pkey Key
+	var val Val
+	pkey, val, data = Key(data[:32]), Val(data[32:64]), data[64:]
 	if pkey == key {
-		return val, true, nil
+		return ErrMalformedProof
 	}
-	return Val{}, false, nil
+
+	err = verifyInternal(snap, key, pkey, val, data)
+	return err
 }
 
 // emptyTreeHash returns the parent hash for a root no child nodes.

--- a/mpt/tree_test.go
+++ b/mpt/tree_test.go
@@ -341,15 +341,23 @@ func (tt *testTree) get(key Key, val Val, ok bool) {
 		tt.t.Fatalf("Tree.Prove: %v\n\nLog:\n%s", err, &tt.log)
 	}
 
-	v, o, err := Verify(snap, key, proof)
+	ty, err := GetProofType(proof)
 	if err != nil {
-		tt.t.Fatalf("Verify %v: %v\nSnap: %v\nProof: %x\n\nLog:\n%s", key, err, snap, proof, &tt.log)
-	}
-	if v != val || o != ok {
-		tt.t.Fatalf("get %v:\nhave %v, %v\nwant %v, %v\n\nLog:\n%s", key, v, o, val, ok, &tt.log)
+		tt.t.Fatalf("Tree.GetProofType: %v\n\nLog:\n%s", err, &tt.log)
 	}
 
-	//fmt.Fprintf(&tt.log, "get(%v)\n", key)
+	switch ty {
+	case Inclusion:
+		err := VerifyInclusion(snap, key, val, proof)
+		if err != nil {
+			tt.t.Fatalf("VerifyInclusion %v: %v\nSnap: %v\nProof: %x\n\nLog:\n%s", key, err, snap, proof, &tt.log)
+		}
+	case Noninclusion:
+		err := VerifyNoninclusion(snap, key, proof)
+		if err != nil {
+			tt.t.Fatalf("VerifyNoninclusion %v: %v\nSnap: %v\nProof: %x\n\nLog:\n%s", key, err, snap, proof, &tt.log)
+		}
+	}
 }
 
 func BenchmarkSet1K_100K(b *testing.B) {


### PR DESCRIPTION
Ported from https://github.com/rsc/tmp/pull/21

We've been basing [WAICT's](https://blog.cloudflare.com/improving-the-trustworthiness-of-javascript-on-the-web/) transparency log on this MPT design (our [spec](https://github.com/waict-wg/waict-transparency-spec/blob/3b7ec0fb8dcaeca50a7c7967f405f83a2c8ba93b/merkle-patricia-tree.md) uses a more functional-style def, but it's identical). In our inclusion proofs, we [serve leaf data](https://github.com/waict-wg/waict-transparency-spec/blob/3b7ec0fb8dcaeca50a7c7967f405f83a2c8ba93b/waict-proofs.md#inclusion-proofs) that the client then hashes to get the leaf `val`. For us, there is no reason for the MPT inclusion proof to also have a copy of `val`. At best, it is a redundancy, and at worst it is a potential area for implementations to differ on behavior.

More generally, I suspect anyone using this MPT structure will have their own way of conveying the value of a leaf. So I think `val` should be left outside the proof.

This PR removes `val` from MPT inclusion proofs, and updates the implementation accordingly. I've also taken the liberty of breaking up the `Verify` function into `VerifyInclusion` and `VerifyNoninclusion`, since they inherently have different type signatures and I didn't see a need to have them unified as one function (I've never seen a use case where a client doesn't know which one to expect). Also I removed the `val` return value from `VerifyNoninclusion` since it's not clear what someone would do with the value of a key adjacent to the one being queried.

Let me know what you think!