### PR TITLE
mpt: three cleanup commits

### DIFF
--- a/mpt/disk.go
+++ b/mpt/disk.go
@@ -84,8 +84,13 @@ var _ pmem.File = File(nil)
 // A diskTree is an on-disk [Tree].
 type diskTree struct {
 	// mmu is the memory mapping mutex.
+	//
 	// All methods except Close do mmu.RLock and mmu.RUnlock
-	// in order to be allowed to use pmem.Data() aka mem.
+	// in order to be allowed to read and write pmem.Data() aka mem.
+	// Note that it is OK to write the memory while holding the "RLock".
+	// The point of the shared RLock is to stop Close from unmapping
+	// the memory entirely.
+	//
 	// Close calls mmu.Lock/mmu.Unlock to wait for all other
 	// method calls to finish before unmapping the memory.
 	mmu  sync.RWMutex
@@ -245,8 +250,9 @@ func (t *diskTree) Close() error {
 	if t.closed {
 		return fmt.Errorf("tree already closed")
 	}
+	t.closed = true
 	if err := t.pmem.Sync(); err != nil {
-		return t.broken(err)
+		t.broken(err)
 	}
 	if err := t.pmem.Release(); err != nil {
 		t.broken(err)
@@ -262,10 +268,12 @@ func (t *diskTree) Close() error {
 	if err := t.file2.Close(); err != nil {
 		t.broken(err)
 	}
+	if err := t.leaf.Close(); err != nil {
+		t.broken(err)
+	}
 	if t.err != nil {
 		return t.err
 	}
-	t.closed = true
 	t.err = errors.New("tree is closed") // stop future method calls
 	return nil
 }

--- a/mpt/disk_test.go
+++ b/mpt/disk_test.go
@@ -236,7 +236,7 @@ func testDiskRecovery(t *testing.T) {
 		t.Fatal(err)
 	}
 	tree := xtree.(*diskTree)
-	defer tree.Close() // relelase pmem on test failure
+	defer tree.Close() // release pmem on test failure
 
 	tree.pmem.SetConstantFlushing(true)
 	tt.tree = tree

--- a/mpt/dmem.go
+++ b/mpt/dmem.go
@@ -88,6 +88,8 @@ func (t *diskTree) snap(version int64) error {
 		// updating arbitrarily many hashes during rehash.
 		// Without group, ordering matters: write hash before dirty
 		// and both before version.
+		//
+		// Also note: dirty implies that tree is non-empty, so there is a root.
 		root, err := t.node(t.hdr().root())
 		if err != nil {
 			return err
@@ -113,6 +115,9 @@ func (t *diskTree) snap(version int64) error {
 
 // Version returns version information about the tree.
 func (t *diskTree) Version() (version int64, exact bool) {
+	t.mmu.RLock()
+	defer t.mmu.RUnlock()
+
 	hdr := t.hdr()
 	return hdr.version(), hdr.exact()
 }

--- a/mpt/dmem.go
+++ b/mpt/dmem.go
@@ -256,6 +256,9 @@ func (t *diskTree) Predict(changes []KeyVal) (Hash, error) {
 		return Hash{}, ErrModifiedTree
 	}
 
+	if err := checkChanges(changes); err != nil {
+		return Hash{}, err
+	}
 	s, list, err := t.predict([]node{}, t.hdr().root(), -1, changes)
 	if err != nil {
 		return Hash{}, err

--- a/mpt/internal/slicemath/slicemath.go
+++ b/mpt/internal/slicemath/slicemath.go
@@ -7,14 +7,15 @@ import "unsafe"
 
 // contains reports whether big contains little;
 // that is, it reports whether little is a subslice of big.
+// If either big or little is empty, contains returns false.
 func contains(big, little []byte) bool {
-	return uintptr(unsafe.Pointer(&big[0])) <= uintptr(unsafe.Pointer(&little[0])) &&
+	return len(big) > 0 && len(little) > 0 &&
+		uintptr(unsafe.Pointer(&big[0])) <= uintptr(unsafe.Pointer(&little[0])) &&
 		uintptr(unsafe.Pointer(&little[len(little)-1])) <= uintptr(unsafe.Pointer(&big[len(big)-1]))
 }
 
 // Offset reports little's starting position within big.
 // If big does not contain little, Offset returns ^uintptr(0), false.
-// The caller must have checked sliceContains(big, little) already.
 func Offset(big, little []byte) (offset uintptr, ok bool) {
 	if !contains(big, little) {
 		return ^uintptr(0), false

--- a/mpt/mem.go
+++ b/mpt/mem.go
@@ -191,6 +191,9 @@ func (t *memTree) Predict(changes []KeyVal) (Hash, error) {
 		return Hash{}, ErrModifiedTree
 	}
 
+	if err := checkChanges(changes); err != nil {
+		return Hash{}, err
+	}
 	s, list := t.predict([]node{}, t.root, -1, changes)
 	for _, kv := range list {
 		s = reduce(append(s, node{prefix(kv.Key, 256), hashLeaf(kv.Key, kv.Val)}))

--- a/mpt/mptload.go
+++ b/mpt/mptload.go
@@ -19,7 +19,7 @@ import (
 )
 
 func usage() {
-	fmt.Fprintf(os.Stderr, "usage: mptload db1 db2 keys.txt\n")
+	fmt.Fprintf(os.Stderr, "usage: mptload db1 db2 leafdb keys.txt\n")
 	os.Exit(2)
 }
 
@@ -27,12 +27,12 @@ func main() {
 	log.SetPrefix("mptload: ")
 	flag.Usage = usage
 	flag.Parse()
-	if flag.NArg() != 3 {
+	if flag.NArg() != 4 {
 		usage()
 	}
 
-	file1, file2, keys := flag.Arg(0), flag.Arg(1), flag.Arg(2)
-	tree, err := mpt.Create(file1, file2)
+	file1, file2, file3, keys := flag.Arg(0), flag.Arg(1), flag.Arg(2), flag.Arg(3)
+	tree, err := mpt.Create(file1, file2, file3)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -53,7 +53,7 @@ func main() {
 		}
 	}
 	log.Print("snap")
-	if _, err := tree.Snap(); err != nil {
+	if _, err := tree.Snap(1); err != nil {
 		log.Fatal(err)
 	}
 	log.Print("sync")

--- a/mpt/tree.go
+++ b/mpt/tree.go
@@ -30,6 +30,10 @@ type Tree interface {
 	// applying the given changes (sorted by key) to the tree,
 	// without modifying the tree.
 	//
+	// It is an error to call Predict with changes that are not
+	// sorted by increasing key or that contain duplicate keys.
+	// Implementations may return [ErrInvalidPredict] in this case.
+	//
 	// It is an error to call Predict if Set has been called without
 	// a subsequent call to Snap: in that case, the caller does not
 	// know what the current hash is.
@@ -87,6 +91,20 @@ type Tree interface {
 
 // ErrModifiedTree indicates that Prove was called after a Set without a Snap.
 var ErrModifiedTree = errors.New("tree modified without snapshot")
+
+// ErrInvalidPredict indicates that Predict was passed a set of
+// changes that was not sorted by increasing key or contained
+// duplicates.
+var ErrInvalidPredict = errors.New("invalid predicted changes")
+
+func checkChanges(changes []KeyVal) error {
+	for i := 0; i < len(changes)-1; i++ {
+		if bytes.Compare(changes[i].Key[:], changes[i+1].Key[:]) >= 0 {
+			return ErrInvalidPredict
+		}
+	}
+	return nil
+}
 
 // A Key is a key used by a Tree.
 // It is usually a cryptographic hash of the actual key data.

--- a/mpt/tree.go
+++ b/mpt/tree.go
@@ -67,6 +67,9 @@ type Tree interface {
 	// to flush the changes to disk. (If the files are *os.File files,
 	// Sync calls fsync(2).)
 	//
+	// Sync must not be called concurrently with other calls to Sync
+	// or (as noted above) with calls to Set.
+	//
 	// Even in the absence of calls to Sync, a Tree provides the
 	// guarantee that on recovery from a crash, it can identify the
 	// latest snapshot whose Set calls are fully included in the tree.
@@ -366,11 +369,7 @@ func hashInner(b int, left, right Hash) Hash {
 	copy(enc[:32], left[:])
 	copy(enc[32:64], right[:])
 	enc[64] = byte(b)
-	h := sha256.Sum256(enc[:])
-	if right == (Hash{}) {
-		panic("zero")
-	}
-	return h
+	return sha256.Sum256(enc[:])
 }
 
 func reduce(s []node) []node {

--- a/mpt/tree_test.go
+++ b/mpt/tree_test.go
@@ -446,5 +446,22 @@ func TestPredict(t *testing.T) {
 		if hash != want {
 			t.Errorf("Predict = %v, want %v", hash, want)
 		}
+
+		_, err = tt.tree.Predict([]KeyVal{
+			{Key: h("20...0"), Val: v(4)},
+			{Key: h("20...0"), Val: v(5)},
+		})
+		if err != ErrInvalidPredict {
+			t.Errorf("Predict with duplicate keys: %v, want ErrInvalidPredict", err)
+		}
+
+		_, err = tt.tree.Predict([]KeyVal{
+			{Key: h("40...0"), Val: v(4)},
+			{Key: h("20...0"), Val: v(5)},
+		})
+		if err != ErrInvalidPredict {
+			t.Errorf("Predict with inverted keys: %v, want ErrInvalidPredict", err)
+		}
+
 	})
 }


### PR DESCRIPTION
Mostly cleanup and one sanity check suggested by an LLM code review:
make Predict verify that the changes are in sorted order and contain no duplicates.
This is already required by doc comment, but Predict did not check,
and the results would be confusing if the calling code violated the requirement.
Predict is already O(N) so an O(N) scan to check sorted order with no duplicates is asymptotically free.

