### PR TITLE
[MPT] Set ID on Open

### DIFF
--- a/mpt/internal/pmem/pmem.go
+++ b/mpt/internal/pmem/pmem.go
@@ -380,6 +380,7 @@ func open(magic string, file1, file2, disk File) (_ *Mem, err error) {
 	if r1.id != r2.id {
 		return nil, fmt.Errorf("inconsistent pmem files: mismatched IDs")
 	}
+	m.id = r1.id
 	if r1.seq == r2.seq {
 		return nil, fmt.Errorf("inconsistent pmem files: identical sequence numbers (%#x == %#x)", r1.seq, r2.seq)
 	}

--- a/mpt/internal/pmem/pmem_test.go
+++ b/mpt/internal/pmem/pmem_test.go
@@ -101,6 +101,36 @@ func testRecovery(t *testing.T) {
 	check(t, mem.UnsafeUnmap())
 }
 
+func TestOpenPopulatesID(t *testing.T) {
+	tt := &tester{t: t}
+	for i := range tt.file {
+		tt.file[i].tester = tt
+	}
+
+	m, err := Create("magic", &tt.file[0], &tt.file[1], nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tt.setMem(m)
+	createdID := m.id
+	if createdID == [16]byte{} {
+		t.Fatal("created ID is zero")
+	}
+	m.Release()
+	m.UnsafeUnmap()
+
+	m2, err := Open("magic", tt.file[0].clone(), tt.file[1].clone(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer m2.Release()
+	defer m2.UnsafeUnmap()
+
+	if m2.id != createdID {
+		t.Errorf("opened ID %x != created ID %x", m2.id, createdID)
+	}
+}
+
 func randFill(b []byte) []byte {
 	for i := range b {
 		b[i] = byte(rand.N(256))


### PR DESCRIPTION
Leaving this as all zeroes when opening an existing tree for writes can lead to a situation where the tree is corrupted and can no longer be opened.
